### PR TITLE
feat(Fathom): add custom domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import { Fathom } from 'astro-analytics';
 ```
 
 ```html
-<Fathom site="ABCDEF" />
+<Fathom site="ABCDEF" src="https://youdomain.com/script.js" /> (if no src is set it will fallback to https://cdn.usefathom.com/script.js)
 <GoogleAnalytics id="UA-156492295-1" />
 <Metrical app="j5gZ1K26a" />
 <Plausible domain="yourdomain.com" src="https://youdomain.com/yoursript.js" /> (if no src is set it will fallback to https://plausible.io/js/script.js)

--- a/src/Fathom.astro
+++ b/src/Fathom.astro
@@ -1,8 +1,9 @@
 ---
 export interface Props {
   site: string;
+  src: string | undefined;
 }
 
-const { site } = Astro.props;
+const { site, src = 'https://cdn.usefathom.com/script.js'} = Astro.props;
 ---
-<script src="https://cdn.usefathom.com/script.js" data-site={site} defer></script>
+<script src={src} data-site={site} defer></script>


### PR DESCRIPTION
This PR adds support for using a 'custom domain' when using Fathom Analytics. If none is set, the fallback will be used.
https://usefathom.com/docs/script/custom-domains