### PR TITLE
`src` should be an optional prop for Plausible

### DIFF
--- a/src/Plausible.astro
+++ b/src/Plausible.astro
@@ -2,7 +2,7 @@
 
 export interface Props {
   domain: string;
-  src: string | undefined;
+  src?: string;
 }
 
 const { domain, src = 'https://plausible.io/js/script.js' } = Astro.props;


### PR DESCRIPTION
I'm not sure I've approached this the right way, but my type checker was throwing an error if I used the `<Plausible>` component without a `src`. Since there's a default, I believe this should be an optional prop, and it looks like the previous approach of defining the type as `src: string | undefined` was not cluing the type checker in on this. Other astro plugins I looked at were using something like the convention I used here, `src?: string`, so I am proposing that as a change.

I believe that this is the more correct notation for this.