### PR TITLE
Add vercel Analytics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#fbed80",
+        "activityBar.background": "#fbed80",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#06b9a5",
+        "activityBarBadge.foreground": "#15202b",
+        "sash.hoverBorder": "#fbed80",
+        "statusBar.background": "#f9e64f",
+        "statusBar.foreground": "#15202b",
+        "statusBarItem.hoverBackground": "#f7df1e",
+        "statusBarItem.remoteBackground": "#f9e64f",
+        "statusBarItem.remoteForeground": "#15202b",
+        "tab.activeBorder": "#fbed80"
+    },
+    "peacock.color": "#f9e64f"
+}

--- a/README.md
+++ b/README.md
@@ -3,43 +3,41 @@
 _A collection of Astro components for popular web analytics tools_
 
 Supported services:
-
-- [x] ![Fathom Logo](docs/fathom.webp) Fathom
-  - [Website](https://usefathom.com)
-  - [Live Demo](https://app.usefathom.com/demo)
-  - script.js · 5,95 KB
-- [x] ![Google Analytics Logo](docs/ga.webp) Google Analytics
-  - [Website](https://developers.google.com/analytics)
-- [x] ![Metrical Logo](docs/metrical.webp) Metrical
-  - [Website](https://metrical.xyz)
-  - [Live Demo](https://app.metrical.xyz/demo)
-  - script.js · 2,48 KB
-- [x] ![Plausible Logo](docs/plausible.webp) Plausible
-  - [Website](https://plausible.io)
-  - [Live Demo](https://plausible.io/plausible.io)
-  - [GitHub](https://github.com/plausible/analytics)
-  - plausible.js · 1,30 KB · 🥇
-- [x] ![Simple Analytics Logo](docs/simpleanalytics.webp) Simple Analytics
-  - [Website](https://simpleanalytics.com)
-  - [Live Demo](https://simpleanalytics.com/simpleanalytics.com)
-- [x] ![Umami Logo](docs/umami.webp) Umami
-  - [Website](https://umami.is)
-  - [Live Demo](https://app.umami.is/share/8rmHaheU/umami.is)
-  - [GitHub](https://github.com/umami-software/umami)
-  - umami.js · 2,75 KB
-- [x] ![Amplitude Logo](docs/amplitude.webp) Amplitude
-  - [Website](https://amplitude.com)
-  - [Live Demo](https://analytics.amplitude.com/login/my-demo)
-  - [GitHub](https://github.com/amplitude)
-- [x] ![Matomo Logo](docs/matomo.webp) Matomo
-  - [Website](https://matomo.org)
-- [x] 🌱 Minimalanalytics
-  - [Website](https://minimalanalytics.com)
-  - [Gist](https://gist.github.com/DavidKuennen/443121e692175d6fc145e1efb0284ec9)
-  - script.js · 1.56 KB · 🥈
-- [x] Vercel Analytics
-  - [Website](https://vercel.com/docs/concepts/analytics)
-
+* [x] ![Fathom Logo](docs/fathom.webp) Fathom
+  * [Website](https://usefathom.com)
+  * [Live Demo](https://app.usefathom.com/demo)
+  * script.js · 5,95 KB
+* [x] ![Google Analytics Logo](docs/ga.webp) Google Analytics
+  * [Website](https://developers.google.com/analytics)
+* [x] ![Metrical Logo](docs/metrical.webp) Metrical
+  * [Website](https://metrical.xyz)
+  * [Live Demo](https://app.metrical.xyz/demo)
+  * script.js · 2,48 KB
+* [x] ![Plausible Logo](docs/plausible.webp) Plausible
+  * [Website](https://plausible.io)
+  * [Live Demo](https://plausible.io/plausible.io)
+  * [GitHub](https://github.com/plausible/analytics)
+  * plausible.js · 1,30 KB · 🥇
+* [x] ![Simple Analytics Logo](docs/simpleanalytics.webp) Simple Analytics
+  * [Website](https://simpleanalytics.com)
+  * [Live Demo](https://simpleanalytics.com/simpleanalytics.com)
+* [x] ![Umami Logo](docs/umami.webp) Umami
+  * [Website](https://umami.is)
+  * [Live Demo](https://app.umami.is/share/8rmHaheU/umami.is)
+  * [GitHub](https://github.com/umami-software/umami)
+  * umami.js · 2,75 KB
+* [x] ![Amplitude Logo](docs/amplitude.webp) Amplitude
+  * [Website](https://amplitude.com)
+  * [Live Demo](https://analytics.amplitude.com/login/my-demo)
+  * [GitHub](https://github.com/amplitude)
+* [x] ![Matomo Logo](docs/matomo.webp) Matomo
+  * [Website](https://matomo.org)
+* [ ] 🌱 Minimalanalytics
+  * [Website](https://minimalanalytics.com)
+  * [Gist](https://gist.github.com/DavidKuennen/443121e692175d6fc145e1efb0284ec9)
+  * script.js · 1.56 KB · 🥈
+* Vercel Analytics
+  * [Website](https://vercel.com/docs/concepts/analytics)
 ## Installation
 
 ```bash
@@ -53,22 +51,16 @@ yarn add astro-analytics
 ## Usage
 
 ```js
-import { Fathom } from "astro-analytics";
+import { Fathom } from 'astro-analytics';
 ```
 
 ```html
-- <Fathom site="ABCDEF" src="https://youdomain.com/script.js" /> (if no src is
-set it will fallback to https://cdn.usefathom.com/script.js)
-
+<Fathom site="ABCDEF" src="https://youdomain.com/script.js" /> (if no src is set it will fallback to https://cdn.usefathom.com/script.js)
 <GoogleAnalytics id="UA-156492295-1" />
 <Metrical app="j5gZ1K26a" />
-- <Plausible domain="yourdomain.com" src="https://youdomain.com/yoursript.js" />
-(if no src is set it will fallback to https://plausible.io/js/script.js)
-
+<Plausible domain="yourdomain.com" src="https://youdomain.com/yoursript.js" /> (if no src is set it will fallback to https://plausible.io/js/script.js)
 <SimpleAnalytics />
-- <Umami id="4fb7fa4c-5b46-438d-94b3-3a8fb9bc2e8b" src="https://your-umami-app.com/umami.js" />
-
+<Umami id="4fb7fa4c-5b46-438d-94b3-3a8fb9bc2e8b" src="https://your-umami-app.com/umami.js" />
 <Matomo id="1" src="https://yourdomain.com" />
-
 <VercelAnalytics version={1} options={{ analyticsId: string, debug: boolean }} />
 ```

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Supported services:
   - [GitHub](https://github.com/amplitude)
 - [x] ![Matomo Logo](docs/matomo.webp) Matomo
   - [Website](https://matomo.org)
-- [ ] 🌱 Minimalanalytics
+- [x] 🌱 Minimalanalytics
   - [Website](https://minimalanalytics.com)
   - [Gist](https://gist.github.com/DavidKuennen/443121e692175d6fc145e1efb0284ec9)
   - script.js · 1.56 KB · 🥈
-- [] Vercel Analytics
+- [x] Vercel Analytics
   - [Website](https://vercel.com/docs/concepts/analytics)
 
 ## Installation
@@ -57,18 +57,18 @@ import { Fathom } from "astro-analytics";
 ```
 
 ```html
-<Fathom site="ABCDEF" src="https://youdomain.com/script.js" /> (if no src is set
-it will fallback to https://cdn.usefathom.com/script.js)
+- <Fathom site="ABCDEF" src="https://youdomain.com/script.js" /> (if no src is
+set it will fallback to https://cdn.usefathom.com/script.js)
+
 <GoogleAnalytics id="UA-156492295-1" />
 <Metrical app="j5gZ1K26a" />
-<Plausible domain="yourdomain.com" src="https://youdomain.com/yoursript.js" />
+- <Plausible domain="yourdomain.com" src="https://youdomain.com/yoursript.js" />
 (if no src is set it will fallback to https://plausible.io/js/script.js)
+
 <SimpleAnalytics />
-<Umami
-  id="4fb7fa4c-5b46-438d-94b3-3a8fb9bc2e8b"
-  src="https://your-umami-app.com/umami.js"
-/>
+- <Umami id="4fb7fa4c-5b46-438d-94b3-3a8fb9bc2e8b" src="https://your-umami-app.com/umami.js" />
+
 <Matomo id="1" src="https://yourdomain.com" />
-<VercelAnalytics version={1} options={{ analyticsId: string, debug: boolean }}
-/>
+
+<VercelAnalytics version={1} options={{ analyticsId: string, debug: boolean }} />
 ```

--- a/README.md
+++ b/README.md
@@ -3,40 +3,43 @@
 _A collection of Astro components for popular web analytics tools_
 
 Supported services:
-* [x] ![Fathom Logo](docs/fathom.webp) Fathom
-  * [Website](https://usefathom.com)
-  * [Live Demo](https://app.usefathom.com/demo)
-  * script.js · 5,95 KB
-* [x] ![Google Analytics Logo](docs/ga.webp) Google Analytics
-  * [Website](https://developers.google.com/analytics)
-* [x] ![Metrical Logo](docs/metrical.webp) Metrical
-  * [Website](https://metrical.xyz)
-  * [Live Demo](https://app.metrical.xyz/demo)
-  * script.js · 2,48 KB
-* [x] ![Plausible Logo](docs/plausible.webp) Plausible
-  * [Website](https://plausible.io)
-  * [Live Demo](https://plausible.io/plausible.io)
-  * [GitHub](https://github.com/plausible/analytics)
-  * plausible.js · 1,30 KB · 🥇
-* [x] ![Simple Analytics Logo](docs/simpleanalytics.webp) Simple Analytics
-  * [Website](https://simpleanalytics.com)
-  * [Live Demo](https://simpleanalytics.com/simpleanalytics.com)
-* [x] ![Umami Logo](docs/umami.webp) Umami
-  * [Website](https://umami.is)
-  * [Live Demo](https://app.umami.is/share/8rmHaheU/umami.is)
-  * [GitHub](https://github.com/umami-software/umami)
-  * umami.js · 2,75 KB
-* [x] ![Amplitude Logo](docs/amplitude.webp) Amplitude
-  * [Website](https://amplitude.com)
-  * [Live Demo](https://analytics.amplitude.com/login/my-demo)
-  * [GitHub](https://github.com/amplitude)
-* [x] ![Matomo Logo](docs/matomo.webp) Matomo
-  * [Website](https://matomo.org)
-* [ ] 🌱 Minimalanalytics
-  * [Website](https://minimalanalytics.com)
-  * [Gist](https://gist.github.com/DavidKuennen/443121e692175d6fc145e1efb0284ec9)
-  * script.js · 1.56 KB · 🥈
-  
+
+- [x] ![Fathom Logo](docs/fathom.webp) Fathom
+  - [Website](https://usefathom.com)
+  - [Live Demo](https://app.usefathom.com/demo)
+  - script.js · 5,95 KB
+- [x] ![Google Analytics Logo](docs/ga.webp) Google Analytics
+  - [Website](https://developers.google.com/analytics)
+- [x] ![Metrical Logo](docs/metrical.webp) Metrical
+  - [Website](https://metrical.xyz)
+  - [Live Demo](https://app.metrical.xyz/demo)
+  - script.js · 2,48 KB
+- [x] ![Plausible Logo](docs/plausible.webp) Plausible
+  - [Website](https://plausible.io)
+  - [Live Demo](https://plausible.io/plausible.io)
+  - [GitHub](https://github.com/plausible/analytics)
+  - plausible.js · 1,30 KB · 🥇
+- [x] ![Simple Analytics Logo](docs/simpleanalytics.webp) Simple Analytics
+  - [Website](https://simpleanalytics.com)
+  - [Live Demo](https://simpleanalytics.com/simpleanalytics.com)
+- [x] ![Umami Logo](docs/umami.webp) Umami
+  - [Website](https://umami.is)
+  - [Live Demo](https://app.umami.is/share/8rmHaheU/umami.is)
+  - [GitHub](https://github.com/umami-software/umami)
+  - umami.js · 2,75 KB
+- [x] ![Amplitude Logo](docs/amplitude.webp) Amplitude
+  - [Website](https://amplitude.com)
+  - [Live Demo](https://analytics.amplitude.com/login/my-demo)
+  - [GitHub](https://github.com/amplitude)
+- [x] ![Matomo Logo](docs/matomo.webp) Matomo
+  - [Website](https://matomo.org)
+- [ ] 🌱 Minimalanalytics
+  - [Website](https://minimalanalytics.com)
+  - [Gist](https://gist.github.com/DavidKuennen/443121e692175d6fc145e1efb0284ec9)
+  - script.js · 1.56 KB · 🥈
+- [] Vercel Analytics
+  - [Website](https://vercel.com/docs/concepts/analytics)
+
 ## Installation
 
 ```bash
@@ -50,15 +53,22 @@ yarn add astro-analytics
 ## Usage
 
 ```js
-import { Fathom } from 'astro-analytics';
+import { Fathom } from "astro-analytics";
 ```
 
 ```html
-<Fathom site="ABCDEF" src="https://youdomain.com/script.js" /> (if no src is set it will fallback to https://cdn.usefathom.com/script.js)
+<Fathom site="ABCDEF" src="https://youdomain.com/script.js" /> (if no src is set
+it will fallback to https://cdn.usefathom.com/script.js)
 <GoogleAnalytics id="UA-156492295-1" />
 <Metrical app="j5gZ1K26a" />
-<Plausible domain="yourdomain.com" src="https://youdomain.com/yoursript.js" /> (if no src is set it will fallback to https://plausible.io/js/script.js)
+<Plausible domain="yourdomain.com" src="https://youdomain.com/yoursript.js" />
+(if no src is set it will fallback to https://plausible.io/js/script.js)
 <SimpleAnalytics />
-<Umami id="4fb7fa4c-5b46-438d-94b3-3a8fb9bc2e8b" src="https://your-umami-app.com/umami.js" />
+<Umami
+  id="4fb7fa4c-5b46-438d-94b3-3a8fb9bc2e8b"
+  src="https://your-umami-app.com/umami.js"
+/>
 <Matomo id="1" src="https://yourdomain.com" />
+<VercelAnalytics version={1} options={{ analyticsId: string, debug: boolean }}
+/>
 ```

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import Plausible from "./src/Plausible.astro";
 import SimpleAnalytics from "./src/SimpleAnalytics.astro";
 import Umami from "./src/Umami.astro";
 import Amplitude from "./src/Amplitude.astro";
+import VercelAnalytics from "./src/VercelAnalytics.astro";
 
 export {
   Fathom,
@@ -15,5 +16,6 @@ export {
   SimpleAnalytics,
   Umami,
   Amplitude,
+  VercelAnalytics,
   Matomo,
 };

--- a/src/VercelAnalytics.astro
+++ b/src/VercelAnalytics.astro
@@ -1,0 +1,108 @@
+---
+/**  
+
+* ! These are the options for web analytics  
+
+*/
+type Options = {
+  params: { [s: string]: any } | ArrayLike<any>;
+  path: string;
+  analyticsId: string;
+  debug: boolean;
+};
+
+/**
+ * ! The version is the version of the vercel analytics. The assumption is that things won't change.
+ * ! The only two options that must be choosen by the user is the analyticsId and the debug
+ **  The other two options will be provided by the page look at the function at the bottom.
+ */
+type Props = {
+  version: number;
+  options: Omit<Options, "params" | "path">;
+};
+
+const {
+  version,
+  options: { analyticsId, debug },
+} = Astro.props;
+---
+
+<script define:vars={{ version, analyticsId, debug }}>
+  /**
+   * This is the library that must be installed for this one to work.
+   *
+   *
+   */
+  import { onCLS, onFCP, onFID, onLCP, onTTFB } from "web-vitals";
+  {
+    const vitalsUrl = `https://vitals.vercel-analytics.com/v${version}/vitals`;
+
+    function getConnectionSpeed() {
+      return "connection" in navigator &&
+        navigator["connection"] &&
+        typeof navigator["connection"] === "object" &&
+        "effectiveType" in navigator["connection"]
+        ? navigator["connection"]["effectiveType"]
+        : "";
+    }
+
+    //
+
+    function sendToAnalytics(metric, options) {
+      const page = Object.entries(options.params).reduce(
+        (acc, [key, value]) => acc.replace(value, `[${key}]`),
+        options.path
+      );
+
+      const body = {
+        dsn: options.analyticsId,
+        id: metric.id,
+        page,
+        href: location.href,
+        event_name: metric.name,
+        value: metric.value.toString(),
+        speed: getConnectionSpeed(),
+      };
+
+      if (options.debug) {
+        console.log("[Analytics]", metric.name, JSON.stringify(body, null, 2));
+      }
+
+      const blob = new Blob([new URLSearchParams(body).toString()], {
+        // This content type is necessary for `sendBeacon`
+        type: "application/x-www-form-urlencoded",
+      });
+
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon(vitalsUrl, blob);
+      } else
+        fetch(vitalsUrl, {
+          body: blob,
+          method: "POST",
+          credentials: "omit",
+          keepalive: true,
+        });
+    }
+
+    function webVitals(options) {
+      try {
+        onFID((metric) => sendToAnalytics(metric, options));
+        onTTFB((metric) => sendToAnalytics(metric, options));
+        onLCP((metric) => sendToAnalytics(metric, options));
+        onCLS((metric) => sendToAnalytics(metric, options));
+        onFCP((metric) => sendToAnalytics(metric, options));
+      } catch (err) {
+        console.error("[Analytics]", err);
+      }
+    }
+
+    if (analyticsId) {
+      webVitals({
+        analyticsId,
+        path: location.pathname,
+        params: location.search,
+        debug,
+      });
+    }
+  }
+</script>


### PR DESCRIPTION
This is a pull request that fixes #22 . I need a library that allows me to put Vercel Analytics in my site. By creating a pull request to this library I can now and many other people can put a Vercel Analytics script in their Astro sites. The user has to be told to install `web-vitals` for This thing to work. Good Luck. 